### PR TITLE
fix uom display for digital_out

### DIFF
--- a/src/web/WebDataService.cpp
+++ b/src/web/WebDataService.cpp
@@ -422,11 +422,11 @@ void WebDataService::dashboard_data(AsyncWebServerRequest * request) {
                     l.add(Helpers::render_boolean(s, true, true));
                 } else {
                     dv["v"] = Helpers::transformNumFloat(sensor.value(), 0);
+                    dv["u"] = sensor.uom();
                 }
                 if (sensor.type() == AnalogSensor::AnalogType::COUNTER || sensor.type() >= AnalogSensor::AnalogType::DIGITAL_OUT) {
                     dv["c"] = sensor.name();
                 }
-                dv["u"] = sensor.uom();
             }
         }
     }


### PR DESCRIPTION
Digital_out is bool, but uses uom-field for startup selection. So don't send uom for the bool values to dashboard.